### PR TITLE
Respond to events from other buffers, add caching, improve UX, fix bugs

### DIFF
--- a/lua/twoslash-queries/init.lua
+++ b/lua/twoslash-queries/init.lua
@@ -277,6 +277,11 @@ M.attach = function(client, buffer_nr)
   clear_cache(buffer_nr)
   update_types_for_client(client.id)
 
+  vim.api.nvim_clear_autocmds({
+    buffer = buffer_nr,
+    group = activate_types_augroup,
+  })
+
   vim.api.nvim_create_autocmd({
     "BufWinEnter",
     "TabEnter",

--- a/lua/twoslash-queries/init.lua
+++ b/lua/twoslash-queries/init.lua
@@ -1,172 +1,172 @@
 local M = {}
 
 M.config = {
-	is_enabled = true,
-	multi_line = false,
-	highlight = "TypeVirtualText",
+  is_enabled = true,
+  multi_line = false,
+  highlight = "TypeVirtualText",
 }
 
 M.setup = function(args)
-	M.config = vim.tbl_deep_extend("force", M.config, args)
+  M.config = vim.tbl_deep_extend("force", M.config, args)
 end
 
 local query_regex = [[^\s*/\/\s*\^?]]
 
 local virtual_types_ns = vim.api.nvim_create_namespace("virtual_types")
 local get_buffer_number = function()
-	return vim.api.nvim_get_current_buf()
+  return vim.api.nvim_get_current_buf()
 end
 
 local get_whitespaces_string = function(whitespaces)
-	local str = ""
-	local i = 0
-	while i < whitespaces do
-		str = str .. " "
-		i = i + 1
-	end
-	return str
+  local str = ""
+  local i = 0
+  while i < whitespaces do
+    str = str .. " "
+    i = i + 1
+  end
+  return str
 end
 
 local add_virtual_text = function(buffer_nr, position, lines)
-	local virt_text = {}
-	local virt_lines = {}
+  local virt_text = {}
+  local virt_lines = {}
 
-	if M.config.multi_line == true then
-		virt_text = { { lines[1], M.config.highlight } }
-		for i = 2, #lines do
-			virt_lines[i - 1] = { { get_whitespaces_string(position.character + 2) .. lines[i], M.config.highlight } }
-		end
-	else
-		virt_text = { { lines, M.config.highlight } }
-	end
+  if M.config.multi_line == true then
+    virt_text = { { lines[1], M.config.highlight } }
+    for i = 2, #lines do
+      virt_lines[i - 1] = { { get_whitespaces_string(position.character + 2) .. lines[i], M.config.highlight } }
+    end
+  else
+    virt_text = { { lines, M.config.highlight } }
+  end
 
-	vim.api.nvim_buf_set_extmark(buffer_nr, virtual_types_ns, position.line + 1, 0, {
-		virt_text = virt_text,
-		virt_lines = virt_lines,
-	})
+  vim.api.nvim_buf_set_extmark(buffer_nr, virtual_types_ns, position.line + 1, 0, {
+    virt_text = virt_text,
+    virt_lines = virt_lines,
+  })
 end
 
 local get_response_limit_indexes = function(lines)
-	local start = nil
-	local result_limit = vim.regex([[```]])
-	for index, line in pairs(lines) do
-		local match = result_limit:match_str(line)
+  local start = nil
+  local result_limit = vim.regex([[```]])
+  for index, line in pairs(lines) do
+    local match = result_limit:match_str(line)
 
-		if start ~= nil and match then
-			return { start + 1, index - 1 }
-		end
-		if match then
-			start = index
-		end
-	end
-	return { 1, #lines }
+    if start ~= nil and match then
+      return { start + 1, index - 1 }
+    end
+    if match then
+      start = index
+    end
+  end
+  return { 1, #lines }
 end
 
 local format_virtual_text = function(text)
-	local converted = vim.lsp.util.convert_input_to_markdown_lines(text, {})
-	local limits = get_response_limit_indexes(converted)
-	if M.config.multi_line == true then
-		local selected_lines = vim.list_slice(converted, limits[1], limits[2])
-		return selected_lines
-	end
-	local joined_string = table.concat(converted, "", limits[1], limits[2])
-	local escaped = string.gsub(joined_string, "  ", " ")
-	return string.sub(escaped, 1, 120)
+  local converted = vim.lsp.util.convert_input_to_markdown_lines(text, {})
+  local limits = get_response_limit_indexes(converted)
+  if M.config.multi_line == true then
+    local selected_lines = vim.list_slice(converted, limits[1], limits[2])
+    return selected_lines
+  end
+  local joined_string = table.concat(converted, "", limits[1], limits[2])
+  local escaped = string.gsub(joined_string, "  ", " ")
+  return string.sub(escaped, 1, 120)
 end
 
 local get_hover_text = function(client, buffer_nr, line, column)
-	local position = { line = line - 2, character = column }
-	if not vim.api.nvim_buf_is_valid(buffer_nr) then
-		return
-	end
-	local params = { textDocument = vim.lsp.util.make_text_document_params(buffer_nr), position = position }
-	if client then
-		client.request("textDocument/hover", params, function(_, result)
-			if result and result.contents then
-				local formatted_text = format_virtual_text(result.contents.value or result.contents)
-				add_virtual_text(buffer_nr, position, formatted_text)
-			end
-		end)
-	end
+  local position = { line = line - 2, character = column }
+  if not vim.api.nvim_buf_is_valid(buffer_nr) then
+    return
+  end
+  local params = { textDocument = vim.lsp.util.make_text_document_params(buffer_nr), position = position }
+  if client then
+    client.request("textDocument/hover", params, function(_, result)
+      if result and result.contents then
+        local formatted_text = format_virtual_text(result.contents.value or result.contents)
+        add_virtual_text(buffer_nr, position, formatted_text)
+      end
+    end)
+  end
 end
 
 M.remove_queries = function()
-	vim.api.nvim_buf_clear_namespace(0, virtual_types_ns, 0, -1)
+  vim.api.nvim_buf_clear_namespace(0, virtual_types_ns, 0, -1)
 
-	local lines = vim.api.nvim_buf_get_lines(0, 0, -1, false)
-	local regex = vim.regex(query_regex)
+  local lines = vim.api.nvim_buf_get_lines(0, 0, -1, false)
+  local regex = vim.regex(query_regex)
 
-	local removed_lines = 0
+  local removed_lines = 0
 
-	for index, line in pairs(lines) do
-		local match = regex:match_str(line)
+  for index, line in pairs(lines) do
+    local match = regex:match_str(line)
 
-		if match then
-			vim.api.nvim_buf_set_lines(0, index - 1 - removed_lines, index - removed_lines, true, {})
-			removed_lines = removed_lines + 1
-		end
-	end
+    if match then
+      vim.api.nvim_buf_set_lines(0, index - 1 - removed_lines, index - removed_lines, true, {})
+      removed_lines = removed_lines + 1
+    end
+  end
 end
 
 local get_types = function(client, buffer_nr)
-	vim.api.nvim_buf_clear_namespace(buffer_nr, virtual_types_ns, 0, -1)
+  vim.api.nvim_buf_clear_namespace(buffer_nr, virtual_types_ns, 0, -1)
 
-	if M.config.is_enabled == false then
-		return
-	end
+  if M.config.is_enabled == false then
+    return
+  end
 
-	local lines = vim.api.nvim_buf_get_lines(buffer_nr, 0, -1, false)
-	local regex = vim.regex(query_regex)
+  local lines = vim.api.nvim_buf_get_lines(buffer_nr, 0, -1, false)
+  local regex = vim.regex(query_regex)
 
-	for index, line in pairs(lines) do
-		local match = regex:match_str(line)
+  for index, line in pairs(lines) do
+    local match = regex:match_str(line)
 
-		if match then
-			local column = string.find(lines[index], "%^")
-			get_hover_text(client, buffer_nr, index, column)
-		end
-	end
+    if match then
+      local column = string.find(lines[index], "%^")
+      get_hover_text(client, buffer_nr, index, column)
+    end
+  end
 end
 
 M.disable = function()
-	M.config.is_enabled = false
-	vim.api.nvim_buf_clear_namespace(get_buffer_number(), virtual_types_ns, 0, -1)
+  M.config.is_enabled = false
+  vim.api.nvim_buf_clear_namespace(get_buffer_number(), virtual_types_ns, 0, -1)
 end
 
 M.enable = function()
-	M.config.is_enabled = true
-	vim.cmd([[doautocmd User EnableTwoslashQueries]])
+  M.config.is_enabled = true
+  vim.cmd([[doautocmd User EnableTwoslashQueries]])
 end
 
 local activate_types_augroup = vim.api.nvim_create_augroup("activateTypes", { clear = true })
 
 M.attach = function(client, buffer_nr)
-	get_types(client, buffer_nr or 0)
+  get_types(client, buffer_nr or 0)
 
-	vim.api.nvim_create_autocmd({
-		"BufWinEnter",
-		"TabEnter",
-		"InsertLeave",
-		"TextChanged",
-	}, {
-		buffer = buffer_nr,
-		group = activate_types_augroup,
-		callback = function()
-			if client and client.server_capabilities.hoverProvider then
-				get_types(client, buffer_nr or 0)
-			end
-		end,
-	})
+  vim.api.nvim_create_autocmd({
+    "BufWinEnter",
+    "TabEnter",
+    "InsertLeave",
+    "TextChanged",
+  }, {
+    buffer = buffer_nr,
+    group = activate_types_augroup,
+    callback = function()
+      if client and client.server_capabilities.hoverProvider then
+        get_types(client, buffer_nr or 0)
+      end
+    end,
+  })
 
-	vim.api.nvim_create_autocmd("User", {
-		pattern = "EnableTwoslashQueries",
-		group = activate_types_augroup,
-		callback = function()
-			if client and client.server_capabilities.hoverProvider then
-				get_types(client, buffer_nr or 0)
-			end
-		end,
-	})
+  vim.api.nvim_create_autocmd("User", {
+    pattern = "EnableTwoslashQueries",
+    group = activate_types_augroup,
+    callback = function()
+      if client and client.server_capabilities.hoverProvider then
+        get_types(client, buffer_nr or 0)
+      end
+    end,
+  })
 end
 
 return M

--- a/lua/twoslash-queries/init.lua
+++ b/lua/twoslash-queries/init.lua
@@ -211,9 +211,10 @@ local update_hover_text = function(client, buffer_nr, line, column, callback)
   -- When hovering over locations where there is no hover information,
   -- tsserver seems to not respond to the hover request at all.
   -- This means that the callback is not called, and the extmark is never cleared.
-  -- As a workaround, we set a timeout to clear the extmark if the callback
-  -- is not called within a certain time.
-  -- If the response comes later, the extmark will be set at that time.
+  -- As a workaround, clear the extmark after a timeout if the callback
+  -- has not been called yet.
+  -- If the response comes later, the callback will still be called, and the extmark
+  -- will be created as expected.
   vim.defer_fn(function()
     if not finished then
       clear_extmark()

--- a/lua/twoslash-queries/init.lua
+++ b/lua/twoslash-queries/init.lua
@@ -32,7 +32,7 @@ local buf_expire_all_extmarks = function(buffer_nr)
   end
 end
 
----Clear cached extmarks that are marked as expired
+---Clear any cached extmarks that are marked as expired
 ---@param buffer_nr buffer_nr
 local buf_clear_expired_extmarks = function(buffer_nr)
   for line_nr, cache_item in pairs(extmark_cache[buffer_nr] or {}) do
@@ -43,7 +43,7 @@ local buf_clear_expired_extmarks = function(buffer_nr)
   end
 end
 
----Clear any cached extmarks for a buffer where the line's text has changed since the extmark was created
+---Clear any cached extmarks where the target line's text has changed since the extmark was created
 ---@param buffer_nr buffer_nr
 local buf_clear_stale_extmarks = function(buffer_nr)
   for cache_line_nr, cache_item in pairs(extmark_cache[buffer_nr] or {}) do

--- a/lua/twoslash-queries/init.lua
+++ b/lua/twoslash-queries/init.lua
@@ -128,12 +128,7 @@ end
 local update_hover_text = function(client, buffer_nr, line, column, cb)
   local target = vim.api.nvim_buf_get_lines(buffer_nr, line, line + 1, false)[1]
   local position = { line = line - 2, character = column - 1 }
-  if not vim.api.nvim_buf_is_valid(buffer_nr) then
-    cb()
-    return
-  end
-  local params = { textDocument = vim.lsp.util.make_text_document_params(buffer_nr), position = position }
-  if not client then
+  if not client or not vim.api.nvim_buf_is_valid(buffer_nr) then
     cb()
     return
   end
@@ -151,6 +146,7 @@ local update_hover_text = function(client, buffer_nr, line, column, cb)
     end
     cb()
   end
+  local params = { textDocument = vim.lsp.util.make_text_document_params(buffer_nr), position = position }
   local ok = client.request("textDocument/hover", params, function(_, result)
     if not result or not result.contents then
       _cb(false)

--- a/lua/twoslash-queries/init.lua
+++ b/lua/twoslash-queries/init.lua
@@ -105,7 +105,7 @@ end
 
 local update_hover_text = function(client, buffer_nr, line, column, cb)
   local target = vim.api.nvim_buf_get_lines(buffer_nr, line, line + 1, false)[1]
-  local position = { line = line - 2, character = column }
+  local position = { line = line - 2, character = column - 1 }
   if not vim.api.nvim_buf_is_valid(buffer_nr) then
     cb()
     return

--- a/lua/twoslash-queries/init.lua
+++ b/lua/twoslash-queries/init.lua
@@ -179,7 +179,11 @@ local _clear_cache = function(buffer_nr)
 end
 
 local update_types = function(client, buffer_nr)
-  if not client.server_capabilities.hoverProvider or M.config.is_enabled == false then
+  if
+    not client.server_capabilities.hoverProvider
+    or M.config.is_enabled == false
+    or not vim.api.nvim_buf_is_valid(buffer_nr)
+  then
     return
   end
 

--- a/lua/twoslash-queries/init.lua
+++ b/lua/twoslash-queries/init.lua
@@ -166,7 +166,7 @@ local update_hover_text = function(client, buffer_nr, line, column, cb)
     if not finished then
       clear()
     end
-  end, 100)
+  end, 250)
 end
 
 local _clear_cache = function(buffer_nr)

--- a/lua/twoslash-queries/init.lua
+++ b/lua/twoslash-queries/init.lua
@@ -74,6 +74,28 @@ local format_virtual_text = function(text)
   return string.sub(escaped, 1, 120)
 end
 
+local get_indent = function(line_num)
+  local indentexpr = vim.bo.indentexpr
+  if indentexpr ~= "" then
+    vim.v.lnum = line_num
+    local expr_indent_tbl = vim.api.nvim_exec2("echo " .. indentexpr, { output = true })
+    local expr_indent_str = expr_indent_tbl.output
+    local expr_indent = tonumber(expr_indent_str)
+    return expr_indent
+  end
+  local prev_nonblank = vim.fn.prevnonblank(line_num - 1)
+  local prev_nonblank_indent = vim.fn.indent(prev_nonblank)
+  return prev_nonblank_indent
+end
+
+M.add_query = function(pos)
+  local line, col = unpack(pos)
+  local indent = math.max(get_indent(line), get_indent(line + 1))
+  local two_slash_string = string.rep(" ", indent) .. "//"
+  two_slash_string = two_slash_string .. string.rep(" ", col - #two_slash_string) .. "^?"
+  vim.api.nvim_buf_set_lines(0, line, line, false, { two_slash_string })
+end
+
 M.remove_queries = function()
   vim.api.nvim_buf_clear_namespace(0, virtual_types_ns, 0, -1)
 

--- a/plugin/twoslash-queries.lua
+++ b/plugin/twoslash-queries.lua
@@ -1,51 +1,51 @@
 vim.api.nvim_set_hl(0, "TypeVirtualText", { fg = "#CCCC00" })
 
 vim.api.nvim_create_user_command("TwoslashQueriesEnable", function()
-	require("twoslash-queries").enable()
+  require("twoslash-queries").enable()
 end, { nargs = 0, desc = "Enable two slash queries" })
 
 vim.api.nvim_create_user_command("TwoslashQueriesDisable", function()
-	require("twoslash-queries").disable()
+  require("twoslash-queries").disable()
 end, { nargs = 0, desc = "Disable two slash queries" })
 
 vim.api.nvim_create_user_command("TwoslashQueriesInspect", function()
-	-- get cursor position
-	local r, c = unpack(vim.api.nvim_win_get_cursor(0))
+  -- get cursor position
+  local r, c = unpack(vim.api.nvim_win_get_cursor(0))
 
-	-- create a string line //
-	local two_slash_string = "//"
-	local i = 2
-	while i < c do
-		two_slash_string = two_slash_string .. " "
-		i = i + 1
-	end
-	two_slash_string = two_slash_string .. "^?"
+  -- create a string line //
+  local two_slash_string = "//"
+  local i = 2
+  while i < c do
+    two_slash_string = two_slash_string .. " "
+    i = i + 1
+  end
+  two_slash_string = two_slash_string .. "^?"
 
-	-- write string line
-	vim.api.nvim_buf_set_lines(0, r, r, false, { two_slash_string })
+  -- write string line
+  vim.api.nvim_buf_set_lines(0, r, r, false, { two_slash_string })
 end, { nargs = 0, desc = "Inspect variable under the cursor" })
 
 vim.api.nvim_create_user_command("TwoslashQueriesRemove", function()
-	require("twoslash-queries").remove_queries()
+  require("twoslash-queries").remove_queries()
 end, { nargs = 0, desc = "Remove all two slash queries in the current buffer" })
 
 -- Fallback command for backward compatibility
 vim.api.nvim_create_user_command("EnableTwoslashQueries", function()
-	print("EnableTwoslashQueries commad is obsolete. Use TwoslashQueriesEnable")
-	vim.api.nvim_command("TwoslashQueriesEnable")
+  print("EnableTwoslashQueries commad is obsolete. Use TwoslashQueriesEnable")
+  vim.api.nvim_command("TwoslashQueriesEnable")
 end, { nargs = 0, desc = "[Deprecated] Enable two slash queries" })
 
 vim.api.nvim_create_user_command("DisableTwoslashQueries", function()
-	print("DisableTwoslashQueries commad is obsolete. Use TwoslashQueriesDisable")
-	vim.api.nvim_command("TwoslashQueriesDisable")
+  print("DisableTwoslashQueries commad is obsolete. Use TwoslashQueriesDisable")
+  vim.api.nvim_command("TwoslashQueriesDisable")
 end, { nargs = 0, desc = "[Deprecated] Disable two slash queries" })
 
 vim.api.nvim_create_user_command("InspectTwoslashQueries", function()
-	print("InspectTwoslashQueries commad is obsolete. Use TwoslashQueriesInspect")
-	vim.api.nvim_command("TwoslashQueriesInspect")
+  print("InspectTwoslashQueries commad is obsolete. Use TwoslashQueriesInspect")
+  vim.api.nvim_command("TwoslashQueriesInspect")
 end, { nargs = 0, desc = "[Deprecated] Inspect two slash queries" })
 
 vim.api.nvim_create_user_command("RemoveTwoslashQueries", function()
-	print("RemoveTwoslashQueries commad is obsolete. Use TwoslashQueriesRemove")
-	vim.api.nvim_command("TwoslashQueriesRemove")
+  print("RemoveTwoslashQueries commad is obsolete. Use TwoslashQueriesRemove")
+  vim.api.nvim_command("TwoslashQueriesRemove")
 end, { nargs = 0, desc = "[Deprecated] Remove two slash queries" })

--- a/plugin/twoslash-queries.lua
+++ b/plugin/twoslash-queries.lua
@@ -9,20 +9,7 @@ vim.api.nvim_create_user_command("TwoslashQueriesDisable", function()
 end, { nargs = 0, desc = "Disable two slash queries" })
 
 vim.api.nvim_create_user_command("TwoslashQueriesInspect", function()
-  -- get cursor position
-  local r, c = unpack(vim.api.nvim_win_get_cursor(0))
-
-  -- create a string line //
-  local two_slash_string = "//"
-  local i = 2
-  while i < c do
-    two_slash_string = two_slash_string .. " "
-    i = i + 1
-  end
-  two_slash_string = two_slash_string .. "^?"
-
-  -- write string line
-  vim.api.nvim_buf_set_lines(0, r, r, false, { two_slash_string })
+  require("twoslash-queries").add_query(vim.api.nvim_win_get_cursor(0))
 end, { nargs = 0, desc = "Inspect variable under the cursor" })
 
 vim.api.nvim_create_user_command("TwoslashQueriesRemove", function()


### PR DESCRIPTION
Hi! I've been maintaining a fork of twoslash-queries for about a month where I've made quite a few changes. Rather than breaking this into multiple smaller PRs, I'm going to submit this as one big PR. I'm happy to break this up into smaller PRs if that's preferred.

The most major change is that queries are updated when other files in the project are changed. This is nice when you have a query in one file that depends on another file, and you want to see the results of the query change when the other file changes.

In order to support this, I've added a cache to store the results of the queries so we can avoid deleting and re-creating extmarks if the query result hasn't changed. This prevents flickering that would happen when a buffer is modified.

Also, `:TwoslashQueriesInspect` now tries to guess the proper indent, so that when a file is formatted with prettier or another formatter, the query comment's indentation won't change and break the query.

In addition, there are a few other bug fixes, and I've formatted the code with stylua.
