### PR TITLE
fix: set default to true for TypeVirtualText highlight group

### DIFF
--- a/plugin/twoslash-queries.lua
+++ b/plugin/twoslash-queries.lua
@@ -1,4 +1,4 @@
-vim.api.nvim_set_hl(0, "TypeVirtualText", { fg = "#CCCC00" })
+vim.api.nvim_set_hl(0, "TypeVirtualText", { fg = "#CCCC00", default = true })
 
 vim.api.nvim_create_user_command("TwoslashQueriesEnable", function()
   require("twoslash-queries").enable()


### PR DESCRIPTION
This ensures that if the user has a custom highlight group for TypeVirtualText, it will be used instead of the default one.